### PR TITLE
Fix local date formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,12 +434,9 @@
       }
 
       function formatDate(dateString) {
-        // **FIXED:** Removed the problematic timeZone option.
         const [year, month, day] = dateString.split("-");
         const date = new Date(year, month - 1, day);
-        // By adding the timeZone back to UTC here, we ensure the date is parsed correctly from the input
-        // and then displayed in the user's local timezone.
-        const options = { year: "numeric", month: "short", day: "numeric", timeZone: 'UTC' };
+        const options = { year: "numeric", month: "short", day: "numeric" };
         return date.toLocaleDateString("en-US", options);
       }
 


### PR DESCRIPTION
## Summary
- adjust `formatDate` to use the browser's default timezone when formatting workout dates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d41aef1508331bb601853a503ee8a